### PR TITLE
Fix access to the JSON reader context

### DIFF
--- a/src/ThreeDModels/Format/Gltf/Elements/Node.cs
+++ b/src/ThreeDModels/Format/Gltf/Elements/Node.cs
@@ -14,7 +14,7 @@ public class Node : IGltfRootProperty
     /// <summary>
     /// The indices of this node's children.
     /// </summary>
-    public int? Children { get; set; }
+    public List<int>? Children { get; set; }
     /// <summary>
     /// The index of the skin referenced by this node.
     /// </summary>

--- a/src/ThreeDModels/Format/Gltf/Extensions/FB_geometry_metadata.cs
+++ b/src/ThreeDModels/Format/Gltf/Extensions/FB_geometry_metadata.cs
@@ -44,7 +44,7 @@ public class FbGeometryMetadataExtension : IGltfExtension
 {
     public string Name => nameof(FB_geometry_metadata);
 
-    public object? Read(GltfReaderContext context, Type parentType)
+    public object? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context, Type parentType)
     {
         if (parentType != typeof(Scene))
         {
@@ -55,43 +55,43 @@ public class FbGeometryMetadataExtension : IGltfExtension
         SceneBounds? sceneBounds = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(FB_geometry_metadata.VertexCount)))
             {
-                vertexCount = ReadFloat(context);
+                vertexCount = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(FB_geometry_metadata.PrimitiveCount)))
             {
-                primitiveCount = ReadFloat(context);
+                primitiveCount = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(FB_geometry_metadata.SceneBounds)))
             {
-                sceneBounds = SceneBoundsSerialization.Read(context);
+                sceneBounds = SceneBoundsSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(FB_geometry_metadata.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<FB_geometry_metadata>(context);
+                extensions = ExtensionsSerialization.Read<FB_geometry_metadata>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(FB_geometry_metadata.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {
@@ -111,45 +111,45 @@ public class FbGeometryMetadataExtension : IGltfExtension
 
 public class SceneBoundsSerialization
 {
-    public static SceneBounds? Read(GltfReaderContext context)
+    public static SceneBounds? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         float[]? min = null;
         float[]? max = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(SceneBounds.Min)))
             {
-                min = ReadFloatList(context)?.ToArray();
+                min = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(SceneBounds.Max)))
             {
-                max = ReadFloatList(context)?.ToArray();
+                max = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(SceneBounds.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AccessorSparse>(context);
+                extensions = ExtensionsSerialization.Read<AccessorSparse>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(SceneBounds.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AccessorSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AccessorSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AccessorSerialization
 {
-    public static Accessor? Read(GltfReaderContext context)
+    public static Accessor? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? bufferView = null;
         int? byteOffset = null;
@@ -20,71 +20,71 @@ internal static class AccessorSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.BufferView)))
             {
-                bufferView = ReadInteger(context);
+                bufferView = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.ByteOffset)))
             {
-                byteOffset = ReadInteger(context);
+                byteOffset = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.ComponentType)))
             {
-                componentType = ReadInteger(context);
+                componentType = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Normalized)))
             {
-                normalized = ReadBoolean(context);
+                normalized = ReadBoolean(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Count)))
             {
-                count = ReadInteger(context);
+                count = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Type)))
             {
-                type = ReadString(context);
+                type = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Max)))
             {
-                max = ReadFloatList(context);
+                max = ReadFloatList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Min)))
             {
-                min = ReadFloatList(context);
+                min = ReadFloatList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Sparse)))
             {
-                sparse = AccessorSparseSerialization.Read(context);
+                sparse = AccessorSparseSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Accessor>(context);
+                extensions = ExtensionsSerialization.Read<Accessor>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Accessor.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AccessorSparseIndicesSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AccessorSparseIndicesSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AccessorSparseIndicesSerialization
 {
-    public static AccessorSparseIndices? Read(GltfReaderContext context)
+    public static AccessorSparseIndices? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? bufferView = null;
         int? byteOffset = 0;
         int? componentType = 0;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseIndices.BufferView)))
             {
-                bufferView = ReadInteger(context);
+                bufferView = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseIndices.ByteOffset)))
             {
-                byteOffset = ReadInteger(context);
+                byteOffset = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseIndices.ComponentType)))
             {
-                componentType = ReadInteger(context);
+                componentType = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseIndices.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AccessorSparseIndices>(context);
+                extensions = ExtensionsSerialization.Read<AccessorSparseIndices>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseIndices.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AccessorSparseSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AccessorSparseSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AccessorSparseSerialization
 {
-    public static AccessorSparse? Read(GltfReaderContext context)
+    public static AccessorSparse? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? count = null;
         AccessorSparseIndices? indices = null;
         AccessorSparseValues? values = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparse.Count)))
             {
-                count = ReadInteger(context);
+                count = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparse.Indices)))
             {
-                indices = AccessorSparseIndicesSerialization.Read(context);
+                indices = AccessorSparseIndicesSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparse.Values)))
             {
-                values = AccessorSparseValuesSerialization.Read(context);
+                values = AccessorSparseValuesSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparse.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AccessorSparse>(context);
+                extensions = ExtensionsSerialization.Read<AccessorSparse>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparse.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AccessorSparseValuesSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AccessorSparseValuesSerialization.cs
@@ -6,45 +6,45 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AccessorSparseValuesSerialization
 {
-    public static AccessorSparseValues? Read(GltfReaderContext context)
+    public static AccessorSparseValues? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? bufferView = null;
         int? byteOffset = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseValues.BufferView)))
             {
-                bufferView = ReadInteger(context);
+                bufferView = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseValues.ByteOffset)))
             {
-                byteOffset = ReadInteger(context);
+                byteOffset = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseValues.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AccessorSparseValues>(context);
+                extensions = ExtensionsSerialization.Read<AccessorSparseValues>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AccessorSparseValues.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AnimationChannelSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AnimationChannelSerialization.cs
@@ -6,45 +6,45 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AnimationChannelSerialization
 {
-    public static AnimationChannel? Read(GltfReaderContext context)
+    public static AnimationChannel? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? sampler = null;
         AnimationChannelTarget? target = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannel.Sampler)))
             {
-                sampler = ReadInteger(context);
+                sampler = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannel.Target)))
             {
-                target = AnimationChannelTargetSerialization.Read(context);
+                target = AnimationChannelTargetSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannel.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AnimationChannel>(context);
+                extensions = ExtensionsSerialization.Read<AnimationChannel>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannel.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AnimationChannelTargetSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AnimationChannelTargetSerialization.cs
@@ -6,45 +6,45 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AnimationChannelTargetSerialization
 {
-    public static AnimationChannelTarget? Read(GltfReaderContext context)
+    public static AnimationChannelTarget? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? node = null;
         string? path = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannelTarget.Node)))
             {
-                node = ReadInteger(context);
+                node = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannelTarget.Path)))
             {
-                path = ReadString(context);
+                path = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannelTarget.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AnimationChannelTarget>(context);
+                extensions = ExtensionsSerialization.Read<AnimationChannelTarget>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationChannelTarget.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AnimationSamplerSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AnimationSamplerSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AnimationSamplerSerialization
 {
-    public static AnimationSampler? Read(GltfReaderContext context)
+    public static AnimationSampler? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? input = null;
         string? interpolation = null;
         int? output = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationSampler.Input)))
             {
-                input = ReadInteger(context);
+                input = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationSampler.Interpolation)))
             {
-                interpolation = ReadString(context);
+                interpolation = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationSampler.Output)))
             {
-                output = ReadInteger(context);
+                output = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationSampler.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<AnimationSampler>(context);
+                extensions = ExtensionsSerialization.Read<AnimationSampler>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(AnimationSampler.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AnimationSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AnimationSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AnimationSerialization
 {
-    public static Animation? Read(GltfReaderContext context)
+    public static Animation? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         List<AnimationChannel>? channels = null;
         List<AnimationSampler>? samplers = null;
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Animation.Channels)))
             {
-                channels = ReadList(context, JsonTokenType.StartObject, reader => AnimationChannelSerialization.Read(reader)!);
+                channels = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => AnimationChannelSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Animation.Samplers)))
             {
-                samplers = ReadList(context, JsonTokenType.StartObject, reader => AnimationSamplerSerialization.Read(reader)!);
+                samplers = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => AnimationSamplerSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Animation.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Animation.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Animation>(context);
+                extensions = ExtensionsSerialization.Read<Animation>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Animation.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/AssetSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/AssetSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class AssetSerialization
 {
-    public static Asset? Read(GltfReaderContext context)
+    public static Asset? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         string? copyright = null;
         string? generator = null;
@@ -14,47 +14,47 @@ internal static class AssetSerialization
         string? minVersion = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Copyright)))
             {
-                copyright = ReadString(context);
+                copyright = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Generator)))
             {
-                generator = ReadString(context);
+                generator = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Version)))
             {
-                version = ReadString(context);
+                version = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.MinVersion)))
             {
-                minVersion = ReadString(context);
+                minVersion = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Asset>(context);
+                extensions = ExtensionsSerialization.Read<Asset>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/BufferSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/BufferSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class BufferSerialization
 {
-    public static Elements.Buffer? Read(GltfReaderContext context)
+    public static Elements.Buffer? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         string? uri = null;
         int? byteLength = null;
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Elements.Buffer.Uri)))
             {
-                uri = ReadString(context);
+                uri = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Elements.Buffer.ByteLength)))
             {
-                byteLength = ReadInteger(context);
+                byteLength = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Elements.Buffer.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Elements.Buffer.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Elements.Buffer>(context);
+                extensions = ExtensionsSerialization.Read<Elements.Buffer>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Elements.Buffer.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/BufferViewSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/BufferViewSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class BufferViewSerialization
 {
-    public static BufferView? Read(GltfReaderContext context)
+    public static BufferView? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? buffer = null;
         int? byteOffset = null;
@@ -16,55 +16,55 @@ internal static class BufferViewSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.Buffer)))
             {
-                buffer = ReadInteger(context);
+                buffer = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.ByteOffset)))
             {
-                byteOffset = ReadInteger(context);
+                byteOffset = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.ByteLength)))
             {
-                byteLength = ReadInteger(context);
+                byteLength = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.ByteStride)))
             {
-                byteStride = ReadInteger(context);
+                byteStride = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.Target)))
             {
-                target = ReadInteger(context);
+                target = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<BufferView>(context);
+                extensions = ExtensionsSerialization.Read<BufferView>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(BufferView.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/CameraOrthographicSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/CameraOrthographicSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class CameraOrthographicSerialization
 {
-    public static CameraOrthographic? Read(GltfReaderContext context)
+    public static CameraOrthographic? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         float? xmag = null;
         float? ymag = null;
@@ -14,47 +14,47 @@ internal static class CameraOrthographicSerialization
         float? znear = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(xmag)))
             {
-                xmag = ReadFloat(context);
+                xmag = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(ymag)))
             {
-                ymag = ReadFloat(context);
+                ymag = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(zfar)))
             {
-                zfar = ReadFloat(context);
+                zfar = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(znear)))
             {
-                znear = ReadFloat(context);
+                znear = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(CameraOrthographic.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<CameraOrthographic>(context);
+                extensions = ExtensionsSerialization.Read<CameraOrthographic>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(CameraOrthographic.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/CameraPerspectiveSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/CameraPerspectiveSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class CameraPerspectiveSerialization
 {
-    public static CameraPerspective? Read(GltfReaderContext context)
+    public static CameraPerspective? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         float? aspectRatio = null;
         float? yfov = null;
@@ -14,47 +14,47 @@ internal static class CameraPerspectiveSerialization
         float? znear = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(aspectRatio)))
             {
-                aspectRatio = ReadFloat(context);
+                aspectRatio = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(yfov)))
             {
-                yfov = ReadFloat(context);
+                yfov = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(zfar)))
             {
-                zfar = ReadFloat(context);
+                zfar = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(znear)))
             {
-                znear = ReadFloat(context);
+                znear = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(CameraPerspective.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<CameraPerspective>(context);
+                extensions = ExtensionsSerialization.Read<CameraPerspective>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(CameraPerspective.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/CameraSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/CameraSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class CameraSerialization
 {
-    public static Camera? Read(GltfReaderContext context)
+    public static Camera? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         CameraOrthographic? orthographic = null;
         CameraPerspective? perspective = null;
@@ -14,47 +14,47 @@ internal static class CameraSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Camera.Orthographic)))
             {
-                orthographic = CameraOrthographicSerialization.Read(context);
+                orthographic = CameraOrthographicSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Camera.Perspective)))
             {
-                perspective = CameraPerspectiveSerialization.Read(context);
+                perspective = CameraPerspectiveSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Camera.Type)))
             {
-                type = ReadString(context);
+                type = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Camera.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Camera.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Camera>(context);
+                extensions = ExtensionsSerialization.Read<Camera>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Camera.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/ElementReaderDelegates.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/ElementReaderDelegates.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
+
 namespace ThreeDModels.Format.Gltf.IO;
 
-public delegate T ArrayElementReader<T>(GltfReaderContext context);
+public delegate T ArrayElementReader<T>(ref Utf8JsonReader jsonReader, GltfReaderContext context);
 
-public delegate object? ExtensionElementReader(GltfReaderContext context, Type parentType);
+public delegate object? ExtensionElementReader(ref Utf8JsonReader jsonReader, GltfReaderContext context, Type parentType);

--- a/src/ThreeDModels/Format/Gltf/IO/ExtensionsSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/ExtensionsSerialization.cs
@@ -4,35 +4,35 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 public static class ExtensionsSerialization
 {
-    public static Dictionary<string, object?>? Read<TParent>(GltfReaderContext context)
+    public static Dictionary<string, object?>? Read<TParent>(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         Dictionary<string, object?>? extensions = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            else if (context.JsonReader.TokenType != JsonTokenType.PropertyName)
+            else if (jsonReader.TokenType != JsonTokenType.PropertyName)
             {
                 throw new InvalidDataException("Failed to find extension property name");
             }
-            var propertyName = context.JsonReader.GetString()!;
+            var propertyName = jsonReader.GetString()!;
             if (context.Extensions.TryGetValue(propertyName, out var reader))
             {
                 extensions ??= [];
-                extensions.Add(propertyName, reader(context, typeof(TParent)));
+                extensions.Add(propertyName, reader(ref jsonReader, context, typeof(TParent)));
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/ExtrasSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/ExtrasSerialization.cs
@@ -1,8 +1,10 @@
+using System.Text.Json;
+
 namespace ThreeDModels.Format.Gltf.IO;
 
 public static class ExtrasSerialization
 {
-    public static object? Read(GltfReaderContext context)
+    public static object? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         // TODO: implement
         throw new NotImplementedException();

--- a/src/ThreeDModels/Format/Gltf/IO/GltfReader.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/GltfReader.cs
@@ -70,13 +70,14 @@ public class GltfReader
             binaryReader.BaseStream.Seek(0, SeekOrigin.Begin);
             jsonChunk = binaryReader.ReadBytes((int)binaryReader.BaseStream.Length);
         }
-        var context = new GltfReaderContext(new Utf8JsonReader(jsonChunk), _extensions);
-        context.JsonReader.Read();
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        var jsonReader = new Utf8JsonReader(jsonChunk);
+        var context = new GltfReaderContext(_extensions);
+        jsonReader.Read();
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException($"Failed to find {nameof(Gltf)} property");
         }
@@ -99,88 +100,88 @@ public class GltfReader
         List<Texture>? textures = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.ExtensionsUsed)))
             {
-                extensionsUsed = ReadStringList(context);
+                extensionsUsed = ReadStringList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.ExtensionsRequired)))
             {
-                extensionsRequired = ReadStringList(context);
+                extensionsRequired = ReadStringList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Accessors)))
             {
-                accessors = ReadList(context, JsonTokenType.StartObject, reader => AccessorSerialization.Read(reader)!);
+                accessors = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => AccessorSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Animations)))
             {
-                animations = ReadList(context, JsonTokenType.StartObject, reader => AnimationSerialization.Read(reader)!);
+                animations = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => AnimationSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Asset)))
             {
-                asset = AssetSerialization.Read(context);
+                asset = AssetSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Buffers)))
             {
-                buffers = ReadList(context, JsonTokenType.StartObject, reader => BufferSerialization.Read(reader)!);
+                buffers = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => BufferSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.BufferViews)))
             {
-                bufferViews = ReadList(context, JsonTokenType.StartObject, reader => BufferViewSerialization.Read(reader)!);
+                bufferViews = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => BufferViewSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Cameras)))
             {
-                cameras = ReadList(context, JsonTokenType.StartObject, reader => CameraSerialization.Read(reader)!);
+                cameras = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => CameraSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Images)))
             {
-                images = ReadList(context, JsonTokenType.StartObject, reader => ImageSerialization.Read(reader)!);
+                images = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => ImageSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Materials)))
             {
-                materials = ReadList(context, JsonTokenType.StartObject, reader => MaterialSerialization.Read(reader)!);
+                materials = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => MaterialSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Meshes)))
             {
-                meshes = ReadList(context, JsonTokenType.StartObject, reader => MeshSerialization.Read(reader)!);
+                meshes = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => MeshSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Nodes)))
             {
-                nodes = ReadList(context, JsonTokenType.StartObject, reader => NodeSerialization.Read(reader)!);
+                nodes = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => NodeSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Samplers)))
             {
-                samplers = ReadList(context, JsonTokenType.StartObject, reader => SamplerSerialization.Read(reader)!);
+                samplers = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => SamplerSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Scene)))
             {
-                scene = ReadInteger(context);
+                scene = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Scenes)))
             {
-                scenes = ReadList(context, JsonTokenType.StartObject, reader => SceneSerialization.Read(reader)!);
+                scenes = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => SceneSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Skins)))
             {
-                skins = ReadList(context, JsonTokenType.StartObject, reader => SkinSerialization.Read(reader)!);
+                skins = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => SkinSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Textures)))
             {
-                textures = ReadList(context, JsonTokenType.StartObject, reader => TextureSerialization.Read(reader)!);
+                textures = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => TextureSerialization.Read(ref reader, ctx)!);
             }
-            else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Extensions)))
+            else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Gltf>(context);
+                extensions = ExtensionsSerialization.Read<Gltf>(ref jsonReader, context);
             }
-            else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Asset.Extras)))
+            else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Gltf.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/GltfReaderContext.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/GltfReaderContext.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace ThreeDModels.Format.Gltf.IO;
 
 public class GltfReaderContext

--- a/src/ThreeDModels/Format/Gltf/IO/GltfReaderContext.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/GltfReaderContext.cs
@@ -2,8 +2,12 @@ using System.Text.Json;
 
 namespace ThreeDModels.Format.Gltf.IO;
 
-public readonly ref struct GltfReaderContext(Utf8JsonReader jsonReader, Dictionary<string, ExtensionElementReader> extensions)
+public class GltfReaderContext
 {
-    internal readonly Dictionary<string, ExtensionElementReader> Extensions = extensions;
-    public readonly Utf8JsonReader JsonReader = jsonReader;
+    internal readonly Dictionary<string, ExtensionElementReader> Extensions;
+
+    internal GltfReaderContext(Dictionary<string, ExtensionElementReader> extensions)
+    {
+        Extensions = extensions;
+    }
 }

--- a/src/ThreeDModels/Format/Gltf/IO/IGltfExtension.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/IGltfExtension.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace ThreeDModels.Format.Gltf.IO;
 
 public interface IGltfExtension
@@ -6,5 +8,5 @@ public interface IGltfExtension
     /// The name of the extension.
     /// </summary>
     public string Name { get; }
-    public object? Read(GltfReaderContext context, Type parentType);
+    public object? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context, Type parentType);
 }

--- a/src/ThreeDModels/Format/Gltf/IO/ImageSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/ImageSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class ImageSerialization
 {
-    public static Image? Read(GltfReaderContext context)
+    public static Image? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         string? uri = null;
         string? mimeType = null;
@@ -14,47 +14,47 @@ internal static class ImageSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Image.Uri)))
             {
-                uri = ReadString(context);
+                uri = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Image.MimeType)))
             {
-                mimeType = ReadString(context);
+                mimeType = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Image.BufferView)))
             {
-                bufferView = ReadInteger(context);
+                bufferView = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Image.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Image.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Image>(context);
+                extensions = ExtensionsSerialization.Read<Image>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Image.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/IntegerMapSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/IntegerMapSerialization.cs
@@ -6,40 +6,40 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 public static class IntegerMapSerialization
 {
-    public static IntegerMap? Read(GltfReaderContext context)
+    public static IntegerMap? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         IntegerMap integerMap = [];
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(IntegerMap.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<IntegerMap>(context);
+                extensions = ExtensionsSerialization.Read<IntegerMap>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(IntegerMap.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {
-                integerMap.Add(propertyName!, (int)ReadInteger(context)!);
+                integerMap.Add(propertyName!, (int)ReadInteger(ref jsonReader)!);
             }
         }
         integerMap.Extensions = extensions;

--- a/src/ThreeDModels/Format/Gltf/IO/MaterialNormalTextureInfoSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/MaterialNormalTextureInfoSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class MaterialNormalTextureInfoSerialization
 {
-    public static MaterialNormalTextureInfo? Read(GltfReaderContext context)
+    public static MaterialNormalTextureInfo? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? index = null;
         int? texCoord = null;
         float? scale = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialNormalTextureInfo.Index)))
             {
-                index = ReadInteger(context);
+                index = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialNormalTextureInfo.TexCoord)))
             {
-                texCoord = ReadInteger(context);
+                texCoord = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialNormalTextureInfo.Scale)))
             {
-                scale = ReadFloat(context);
+                scale = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialNormalTextureInfo.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<MaterialNormalTextureInfo>(context);
+                extensions = ExtensionsSerialization.Read<MaterialNormalTextureInfo>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialNormalTextureInfo.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/MaterialOcclusionTextureInfoSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/MaterialOcclusionTextureInfoSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class MaterialOcclusionTextureInfoSerialization
 {
-    public static MaterialOcclusionTextureInfo? Read(GltfReaderContext context)
+    public static MaterialOcclusionTextureInfo? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? index = null;
         int? texCoord = null;
         float? strength = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialOcclusionTextureInfo.Index)))
             {
-                index = ReadInteger(context);
+                index = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialOcclusionTextureInfo.TexCoord)))
             {
-                texCoord = ReadInteger(context);
+                texCoord = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialOcclusionTextureInfo.Strength)))
             {
-                strength = ReadFloat(context);
+                strength = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialOcclusionTextureInfo.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<MaterialOcclusionTextureInfo>(context);
+                extensions = ExtensionsSerialization.Read<MaterialOcclusionTextureInfo>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialOcclusionTextureInfo.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/MaterialPbrMetallicRoughnessSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/MaterialPbrMetallicRoughnessSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class MaterialPbrMetallicRoughnessSerialization
 {
-    public static MaterialPbrMetallicRoughness? Read(GltfReaderContext context)
+    public static MaterialPbrMetallicRoughness? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         float[]? baseColorFactor = null;
         TextureInfo? baseColorTexture = null;
@@ -15,51 +15,51 @@ internal static class MaterialPbrMetallicRoughnessSerialization
         TextureInfo? metallicRoughnessTexture = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.BaseColorFactor)))
             {
-                baseColorFactor = ReadFloatList(context)?.ToArray();
+                baseColorFactor = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.BaseColorTexture)))
             {
-                baseColorTexture = TextureInfoSerialization.Read(context);
+                baseColorTexture = TextureInfoSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.MetallicFactor)))
             {
-                metallicFactor = ReadFloat(context);
+                metallicFactor = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.RoughnessFactor)))
             {
-                roughnessFactor = ReadFloat(context);
+                roughnessFactor = ReadFloat(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.MetallicRoughnessTexture)))
             {
-                metallicRoughnessTexture = TextureInfoSerialization.Read(context);
+                metallicRoughnessTexture = TextureInfoSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<MaterialPbrMetallicRoughness>(context);
+                extensions = ExtensionsSerialization.Read<MaterialPbrMetallicRoughness>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MaterialPbrMetallicRoughness.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/MaterialSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/MaterialSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class MaterialSerialization
 {
-    public static Material? Read(GltfReaderContext context)
+    public static Material? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         MaterialPbrMetallicRoughness? pbrMetallicRoughness = null;
         MaterialNormalTextureInfo? normalTexture = null;
@@ -19,67 +19,67 @@ internal static class MaterialSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.PbrMetallicRoughness)))
             {
-                pbrMetallicRoughness = MaterialPbrMetallicRoughnessSerialization.Read(context);
+                pbrMetallicRoughness = MaterialPbrMetallicRoughnessSerialization.Read(ref jsonReader, context);
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.NormalTexture)))
             {
-                normalTexture = MaterialNormalTextureInfoSerialization.Read(context);
+                normalTexture = MaterialNormalTextureInfoSerialization.Read(ref jsonReader, context);
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.OcclusionTexture)))
             {
-                occlusionTexture = MaterialOcclusionTextureInfoSerialization.Read(context);
+                occlusionTexture = MaterialOcclusionTextureInfoSerialization.Read(ref jsonReader, context);
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.EmissiveTexture)))
             {
-                emissiveTexture = TextureInfoSerialization.Read(context);
+                emissiveTexture = TextureInfoSerialization.Read(ref jsonReader, context);
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.EmissiveFactor)))
             {
-                emissiveFactor = ReadFloatList(context)?.ToArray();
+                emissiveFactor = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.AlphaMode)))
             {
-                alphaMode = ReadString(context);
+                alphaMode = ReadString(ref jsonReader);
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.AlphaCutoff)))
             {
-                alphaCutoff = ReadFloat(context);
+                alphaCutoff = ReadFloat(ref jsonReader);
             }
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.DoubleSided)))
             {
-                doubleSided = ReadBoolean(context);
+                doubleSided = ReadBoolean(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Material>(context);
+                extensions = ExtensionsSerialization.Read<Material>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Material.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/MeshPrimitiveSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/MeshPrimitiveSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class MeshPrimitiveSerialization
 {
-    public static MeshPrimitive? Read(GltfReaderContext context)
+    public static MeshPrimitive? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         IntegerMap? attributes = null;
         int? indices = null;
@@ -15,51 +15,51 @@ internal static class MeshPrimitiveSerialization
         List<IntegerMap>? targets = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Attributes)))
             {
-                attributes = IntegerMapSerialization.Read(context);
+                attributes = IntegerMapSerialization.Read(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Indices)))
             {
-                indices = ReadInteger(context);
+                indices = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Material)))
             {
-                material = ReadInteger(context);
+                material = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Mode)))
             {
-                mode = ReadInteger(context);
+                mode = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Indices)))
             {
-                targets = ReadList(context, JsonTokenType.StartObject, reader => IntegerMapSerialization.Read(reader)!);
+                targets = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => IntegerMapSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<MeshPrimitive>(context);
+                extensions = ExtensionsSerialization.Read<MeshPrimitive>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(MeshPrimitive.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/MeshSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/MeshSerialization.cs
@@ -6,50 +6,50 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class MeshSerialization
 {
-    public static Mesh? Read(GltfReaderContext context)
+    public static Mesh? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         List<MeshPrimitive>? primitives = null;
         List<float>? weights = null;
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Mesh.Primitives)))
             {
-                primitives = ReadList(context, JsonTokenType.StartObject, reader => MeshPrimitiveSerialization.Read(reader)!);
+                primitives = ReadList(ref jsonReader, context, JsonTokenType.StartObject, (ref Utf8JsonReader reader, GltfReaderContext ctx) => MeshPrimitiveSerialization.Read(ref reader, ctx)!);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Mesh.Weights)))
             {
-                weights = ReadFloatList(context);
+                weights = ReadFloatList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Mesh.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Mesh.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Mesh>(context);
+                extensions = ExtensionsSerialization.Read<Mesh>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Mesh.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/NodeSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/NodeSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class NodeSerialization
 {
-    public static Node? Read(GltfReaderContext context)
+    public static Node? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? camera = null;
         int? children = null;
@@ -20,71 +20,71 @@ internal static class NodeSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Camera)))
             {
-                camera = ReadInteger(context);
+                camera = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Children)))
             {
-                children = ReadInteger(context);
+                children = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Skin)))
             {
-                skin = ReadInteger(context);
+                skin = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Matrix)))
             {
-                matrix = ReadFloatList(context)?.ToArray();
+                matrix = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Mesh)))
             {
-                mesh = ReadInteger(context);
+                mesh = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Rotation)))
             {
-                rotation = ReadFloatList(context)?.ToArray();
+                rotation = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Scale)))
             {
-                scale = ReadFloatList(context)?.ToArray();
+                scale = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Translation)))
             {
-                translation = ReadFloatList(context)?.ToArray();
+                translation = ReadFloatList(ref jsonReader, context)?.ToArray();
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Weights)))
             {
-                weights = ReadFloatList(context);
+                weights = ReadFloatList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Node>(context);
+                extensions = ExtensionsSerialization.Read<Node>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/NodeSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/NodeSerialization.cs
@@ -9,7 +9,7 @@ internal static class NodeSerialization
     public static Node? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? camera = null;
-        int? children = null;
+        List<int>? children = null;
         int? skin = null;
         float[]? matrix = null;
         int? mesh = null;
@@ -44,7 +44,7 @@ internal static class NodeSerialization
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Children)))
             {
-                children = ReadInteger(ref jsonReader);
+                children = ReadIntegerList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Node.Skin)))
             {
@@ -118,6 +118,10 @@ internal static class NodeSerialization
         if (weights != null && mesh == null)
         {
             throw new InvalidDataException("Node.mesh must be defined if Node.weights has been defined.");
+        }
+        if (children != null && children.Count == 0)
+        {
+            throw new InvalidDataException("Node.children must have at least one element.");
         }
 
         return new()

--- a/src/ThreeDModels/Format/Gltf/IO/SamplerSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/SamplerSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class SamplerSerialization
 {
-    public static Sampler? Read(GltfReaderContext context)
+    public static Sampler? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? magFilter = null;
         int? minFilter = null;
@@ -15,49 +15,49 @@ internal static class SamplerSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        context.JsonReader.Read();
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        jsonReader.Read();
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException($"Failed to find {nameof(Asset)} property");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.MagFilter)))
             {
-                magFilter = ReadInteger(context);
+                magFilter = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.MinFilter)))
             {
-                minFilter = ReadInteger(context);
+                minFilter = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.WrapS)))
             {
-                wrapS = ReadInteger(context);
+                wrapS = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.WrapT)))
             {
-                wrapT = ReadInteger(context);
+                wrapT = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.WrapT)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Sampler>(context);
+                extensions = ExtensionsSerialization.Read<Sampler>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Sampler.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/SceneSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/SceneSerialization.cs
@@ -6,45 +6,45 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class SceneSerialization
 {
-    public static Scene? Read(GltfReaderContext context)
+    public static Scene? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         List<int>? nodes = null;
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Scene.Nodes)))
             {
-                nodes = ReadIntegerList(context);
+                nodes = ReadIntegerList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Scene.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Scene.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Scene>(context);
+                extensions = ExtensionsSerialization.Read<Scene>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Scene.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/SkinSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/SkinSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class SkinSerialization
 {
-    public static Skin? Read(GltfReaderContext context)
+    public static Skin? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? inverseBindMatrices = null;
         int? skeleton = null;
@@ -14,47 +14,47 @@ internal static class SkinSerialization
         string? name = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Skin.InverseBindMatrices)))
             {
-                inverseBindMatrices = ReadInteger(context);
+                inverseBindMatrices = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Skin.Skeleton)))
             {
-                skeleton = ReadInteger(context);
+                skeleton = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Skin.Joints)))
             {
-                joints = ReadIntegerList(context);
+                joints = ReadIntegerList(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Skin.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Skin.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Skin>(context);
+                extensions = ExtensionsSerialization.Read<Skin>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Skin.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/TextureInfoSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/TextureInfoSerialization.cs
@@ -6,45 +6,45 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class TextureInfoSerialization
 {
-    public static TextureInfo? Read(GltfReaderContext context)
+    public static TextureInfo? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? index = null;
         int? texCoord = null;
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(TextureInfo.Index)))
             {
-                index = ReadInteger(context);
+                index = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(TextureInfo.TexCoord)))
             {
-                texCoord = ReadInteger(context);
+                texCoord = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(TextureInfo.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<TextureInfo>(context);
+                extensions = ExtensionsSerialization.Read<TextureInfo>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(TextureInfo.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/TextureSerialization.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/TextureSerialization.cs
@@ -6,7 +6,7 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 internal static class TextureSerialization
 {
-    public static Texture? Read(GltfReaderContext context)
+    public static Texture? Read(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
         int? sampler = null;
         int? source = null;
@@ -14,43 +14,43 @@ internal static class TextureSerialization
         Dictionary<string, object?>? extensions = null;
         object? extras = null;
 
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartObject)
+        else if (jsonReader.TokenType != JsonTokenType.StartObject)
         {
             throw new InvalidDataException("Failed to find start of property.");
         }
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndObject)
+            if (jsonReader.TokenType == JsonTokenType.EndObject)
             {
                 break;
             }
-            var propertyName = context.JsonReader.GetString();
+            var propertyName = jsonReader.GetString();
             if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Texture.Sampler)))
             {
-                sampler = ReadInteger(context);
+                sampler = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Texture.Source)))
             {
-                source = ReadInteger(context);
+                source = ReadInteger(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Texture.Name)))
             {
-                name = ReadString(context);
+                name = ReadString(ref jsonReader);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Texture.Extensions)))
             {
-                extensions = ExtensionsSerialization.Read<Texture>(context);
+                extensions = ExtensionsSerialization.Read<Texture>(ref jsonReader, context);
             }
             else if (propertyName == JsonNamingPolicy.CamelCase.ConvertName(nameof(Texture.Extras)))
             {
-                extras = ExtrasSerialization.Read(context);
+                extras = ExtrasSerialization.Read(ref jsonReader, context);
             }
             else
             {

--- a/src/ThreeDModels/Format/Gltf/IO/Utf8JsonReaderHelpers.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/Utf8JsonReaderHelpers.cs
@@ -6,16 +6,18 @@ public static class Utf8JsonReaderHelpers
 {
     public static string? ReadString(ref Utf8JsonReader jsonReader)
     {
-        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && !jsonReader.Read())
         {
+            return null;
         }
         return jsonReader.TokenType == JsonTokenType.String ? jsonReader.GetString() : null;
     }
 
     public static bool? ReadBoolean(ref Utf8JsonReader jsonReader)
     {
-        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && !jsonReader.Read())
         {
+            return null;
         }
         return jsonReader.TokenType == JsonTokenType.True || jsonReader.TokenType == JsonTokenType.False
             ? jsonReader.GetBoolean()
@@ -24,16 +26,18 @@ public static class Utf8JsonReaderHelpers
 
     public static float? ReadFloat(ref Utf8JsonReader jsonReader)
     {
-        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && !jsonReader.Read())
         {
+            return null;
         }
         return jsonReader.TokenType == JsonTokenType.Number ? jsonReader.GetSingle() : null;
     }
 
     public static int? ReadInteger(ref Utf8JsonReader jsonReader)
     {
-        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && !jsonReader.Read())
         {
+            return null;
         }
         return jsonReader.TokenType == JsonTokenType.Number ? jsonReader.GetInt32() : null;
     }

--- a/src/ThreeDModels/Format/Gltf/IO/Utf8JsonReaderHelpers.cs
+++ b/src/ThreeDModels/Format/Gltf/IO/Utf8JsonReaderHelpers.cs
@@ -4,87 +4,87 @@ namespace ThreeDModels.Format.Gltf.IO;
 
 public static class Utf8JsonReaderHelpers
 {
-    public static string? ReadString(GltfReaderContext context)
+    public static string? ReadString(ref Utf8JsonReader jsonReader)
     {
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        return context.JsonReader.TokenType == JsonTokenType.String ? context.JsonReader.GetString() : null;
+        return jsonReader.TokenType == JsonTokenType.String ? jsonReader.GetString() : null;
     }
 
-    public static bool? ReadBoolean(GltfReaderContext context)
+    public static bool? ReadBoolean(ref Utf8JsonReader jsonReader)
     {
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        return context.JsonReader.TokenType == JsonTokenType.True || context.JsonReader.TokenType == JsonTokenType.False
-            ? context.JsonReader.GetBoolean()
+        return jsonReader.TokenType == JsonTokenType.True || jsonReader.TokenType == JsonTokenType.False
+            ? jsonReader.GetBoolean()
             : null;
     }
 
-    public static float? ReadFloat(GltfReaderContext context)
+    public static float? ReadFloat(ref Utf8JsonReader jsonReader)
     {
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        return context.JsonReader.TokenType == JsonTokenType.Number ? context.JsonReader.GetSingle() : null;
+        return jsonReader.TokenType == JsonTokenType.Number ? jsonReader.GetSingle() : null;
     }
 
-    public static int? ReadInteger(GltfReaderContext context)
+    public static int? ReadInteger(ref Utf8JsonReader jsonReader)
     {
-        if (context.JsonReader.TokenType == JsonTokenType.PropertyName && context.JsonReader.Read())
+        if (jsonReader.TokenType == JsonTokenType.PropertyName && jsonReader.Read())
         {
         }
-        return context.JsonReader.TokenType == JsonTokenType.Number ? context.JsonReader.GetInt32() : null;
+        return jsonReader.TokenType == JsonTokenType.Number ? jsonReader.GetInt32() : null;
     }
 
-    public static List<T>? ReadList<T>(GltfReaderContext context, JsonTokenType tokenType, ArrayElementReader<T> elementReader)
+    public static List<T>? ReadList<T>(ref Utf8JsonReader jsonReader, GltfReaderContext context, JsonTokenType tokenType, ArrayElementReader<T> elementReader)
     {
-        context.JsonReader.Read();
-        if (context.JsonReader.TokenType == JsonTokenType.Null)
+        jsonReader.Read();
+        if (jsonReader.TokenType == JsonTokenType.Null)
         {
             return null;
         }
-        else if (context.JsonReader.TokenType != JsonTokenType.StartArray)
+        else if (jsonReader.TokenType != JsonTokenType.StartArray)
         {
             throw new InvalidDataException($"Failed to find start of array.");
         }
         var list = new List<T>();
-        while (context.JsonReader.Read())
+        while (jsonReader.Read())
         {
-            if (context.JsonReader.TokenType == JsonTokenType.EndArray)
+            if (jsonReader.TokenType == JsonTokenType.EndArray)
             {
                 break;
             }
-            else if (context.JsonReader.TokenType == JsonTokenType.Comment || context.JsonReader.TokenType == JsonTokenType.Null)
+            else if (jsonReader.TokenType == JsonTokenType.Comment || jsonReader.TokenType == JsonTokenType.Null)
             {
                 continue;
             }
-            else if (context.JsonReader.TokenType == tokenType)
+            else if (jsonReader.TokenType == tokenType)
             {
-                list.Add(elementReader(context));
+                list.Add(elementReader(ref jsonReader, context));
                 continue;
             }
             else
             {
-                throw new InvalidDataException($"Unexpected token: {context.JsonReader.TokenType}");
+                throw new InvalidDataException($"Unexpected token: {jsonReader.TokenType}");
             }
         }
         return list;
     }
 
-    public static List<string>? ReadStringList(GltfReaderContext context)
+    public static List<string>? ReadStringList(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
-        return ReadList(context, JsonTokenType.String, reader => ReadString(reader)!);
+        return ReadList(ref jsonReader, context, JsonTokenType.String, (ref Utf8JsonReader reader, GltfReaderContext _) => ReadString(ref reader)!);
     }
 
-    public static List<int>? ReadIntegerList(GltfReaderContext context)
+    public static List<int>? ReadIntegerList(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
-        return ReadList(context, JsonTokenType.Number, reader => (int)ReadInteger(reader)!);
+        return ReadList(ref jsonReader, context, JsonTokenType.Number, (ref Utf8JsonReader reader, GltfReaderContext _) => (int)ReadInteger(ref reader)!);
     }
 
-    public static List<float>? ReadFloatList(GltfReaderContext context)
+    public static List<float>? ReadFloatList(ref Utf8JsonReader jsonReader, GltfReaderContext context)
     {
-        return ReadList(context, JsonTokenType.Number, reader => (float)ReadFloat(reader)!);
+        return ReadList(ref jsonReader, context, JsonTokenType.Number, (ref Utf8JsonReader reader, GltfReaderContext _) => (float)ReadFloat(ref reader)!);
     }
 }


### PR DESCRIPTION
#### Changes Made

- Removed the `Utf8JsonReader` from the `GltfReaderContext` ref struct.
- Passed the `Utf8JsonReader` as a ref to maintain the original reference.
- Changed the `GltfReaderContext` to a class.
- Changed the `Node.children` type identifier from an integer to an integer list.